### PR TITLE
Fix default network config

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,6 +2,10 @@ require("dotenv").config();
 const express = require("express");
 const bodyParser = require("body-parser");
 const PharosBot = require("./pharos-bot");
+const config = require("./config.json");
+
+const DEFAULT_RPC_URL = config.network.rpc;
+const DEFAULT_CHAIN_ID = config.network.chainId;
 
 const app = express();
 app.set("view engine", "ejs");
@@ -21,8 +25,8 @@ app.post("/init", async (req, res) => {
   const { privateKey1 } = req.body;
 
   const bot = new PharosBot({
-    rpcUrl: process.env.RPC_URL,
-    chainId: parseInt(process.env.CHAIN_ID),
+    rpcUrl: process.env.RPC_URL || DEFAULT_RPC_URL,
+    chainId: parseInt(process.env.CHAIN_ID || DEFAULT_CHAIN_ID),
     privateKeys: [privateKey1],
   });
 


### PR DESCRIPTION
## Summary
- use config.json defaults if RPC_URL or CHAIN_ID env vars are missing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b97eec8948325af00b1bc05727ae9